### PR TITLE
Check firewall rule existence before deleting

### DIFF
--- a/google_cloud_setup.sh
+++ b/google_cloud_setup.sh
@@ -46,6 +46,8 @@ GPU_TYPE=${GPU_TYPE:-nvidia-tesla-p100}
 
 MACHINE_ARCHITECTURE=`uname -m`
 
+firewallCheck=`gcloud compute firewall-rules list --filter="name=(${CLUSTER_NAME})"`
+
 if [ ! -f $MYVALUES_FILE ]; then
     echo "Custom Helm values yaml ($MYVALUES_FILE) not found"
     exit 1
@@ -108,7 +110,12 @@ function join_by(){
 
 function gcloud::cleanup(){
     gcloud::check_installed
-    gcloud compute firewall-rules delete --quiet ${CLUSTER_NAME}
+    if test -z "$firewallCheck"; then
+        echo "firewall rule already deleted"
+    else
+        gcloud compute firewall-rules delete --quiet ${CLUSTER_NAME}
+        echo "firewall rule deleted"
+    fi
     gcloud container clusters delete --quiet --zone ${MACHINE_ZONE}  ${CLUSTER_NAME}
 }
 
@@ -157,7 +164,12 @@ case $1 in
 
     cleanup-cluster )
         gcloud::check_installed
-        gcloud compute firewall-rules delete --quiet ${CLUSTER_NAME}
+        if test -z "$firewallCheck"; then
+            echo "firewall rule already deleted"
+        else
+            gcloud compute firewall-rules delete --quiet ${CLUSTER_NAME}
+            echo "firewall rule deleted"
+        fi
         gcloud container clusters delete --quiet --zone ${MACHINE_ZONE}  ${CLUSTER_NAME}
         ;;
 


### PR DESCRIPTION
This is an attempt to solve #8. 

As discussed on the issue, there is a need to check whether a firewall rule exists before it is deleted. I believe I found a way of doing this but this still needs some review.

1) gcloud has the "gcloud compute firewall-rules list" command, which lists on shell all the existing firewall rules. What I did was to put its result into a variable and check whether it's empty or not. 
2) Even if it's empty, it always prints extra messages such as: 

```$ ./google_cloud_setup.sh delete-cluster
WARNING: --filter : operator evaluation is changing for consistency across Google APIs.  name=rel-2 currently does notmatch but will match in the near future.  Run `gcloud topic filters` for details.

To show all fields of the firewall, please show in JSON format: --format=json
To show all fields in table format, please see the examples in --help.
```

This is because the command "gcloud compute firewall-rules list" on the form I'm using on the script always outputs this message, but I believe it always outputs something like this regardless of the flags we use. 

I wanted to ask for some help here on the following:

1) How to delete this extra messages? User might be confused.
2) If we run the uninstall-chart script after deleting the cluster, it gets a connection refuse. I believe we discussed in #8 that we only needed to add the firewall existence check in what was previously line 111. Is it correct?

Thanks!