### PR TITLE
Add setup script for kind with local registry

### DIFF
--- a/kind-with-registry.sh
+++ b/kind-with-registry.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -o errexit
+
+# desired cluster name; default is "kind"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+
+# create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+reg_ip="$(docker inspect -f '{{.NetworkSettings.IPAddress}}' "${reg_name}")"
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches: 
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_ip}:${reg_port}"]
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      "runtime-config": "apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+EOF


### PR DESCRIPTION
This is a script that can be used to start a local registry and a kind cluster with one master and two worker nodes. It is a modified version of the [official script](https://kind.sigs.k8s.io/docs/user/local-registry/#create-a-cluster-and-registry) provided by kind. The modifications allow the installation of helm (similarly to the change we needed with minikube) and an addition of two worker nodes. I will also document the process of how to use kind for local development in the installation documentation. 

