### PR TITLE
Mapped Master Node's Host Port to its Service Port

### DIFF
--- a/templates/master-deployment.yaml
+++ b/templates/master-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - name: http
               containerPort: 80
-              hostPort: 80
+              hostPort: {{ .Values.master.service.port }}
               protocol: TCP
           # livenessProbe:
           #   httpGet:


### PR DESCRIPTION
The master node's host port currently cannot be changed through the helm values. This is an issue as its default value 80 is often already occupied by other services. I propose to use the service port variable as the host port as it can be configured in the values.yaml.

Closes #53